### PR TITLE
Getting HTTP 410 Gone from Jira, adapt to new API

### DIFF
--- a/JiraBar/Jira/JiraClient.swift
+++ b/JiraBar/Jira/JiraClient.swift
@@ -14,7 +14,7 @@ public class JiraClient {
     @FromKeychain(.jiraToken) var jiraToken
     
     func getIssuesByJql(completion:@escaping ((JiraResponse) -> Void)) -> Void {
-        let url = "\(jiraHost)/rest/api/2/search"
+        let url = "\(jiraHost)/rest/api/3/search/jql"
         let parameters = [
             "jql": jql,
             "fields":"id,assignee,summary,status,issuetype,project",
@@ -36,7 +36,7 @@ public class JiraClient {
                     completion(response)
                 case .failure(let error):
                     print("\(url):  \(error)")
-                    completion(JiraResponse(total: 0))
+                    completion(JiraResponse(isLast: true))
                     sendNotification(body: error.localizedDescription)
                 }
             }

--- a/JiraBar/Jira/JiraDtos.swift
+++ b/JiraBar/Jira/JiraDtos.swift
@@ -3,11 +3,11 @@ import Foundation
 // MARK: issues
 //
 struct JiraResponse: Codable {
-    var total: Int
+    var isLast: Bool
     var issues: [Issue]?
     
     enum CodingKeys: String, CodingKey {
-        case total
+        case isLast
         case issues
     }
 }


### PR DESCRIPTION
Jira now returns a 410 on the `/rest/api/2/search` endpoint, announced here https://developer.atlassian.com/changelog/#CHANGE-2046

I updated the URL and DTO and everything seems to work again.